### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,5 @@
 name = "helloworld"
 version = "0.1.0"
 authors = ["Moritz Beller <moritzbeller@gmx.de>"]
-
+repository = "https://github.com/Inventitech/helloworld.rs"
 [dependencies]


### PR DESCRIPTION
The repository field will simplify identifier naming and something most crates have